### PR TITLE
add datadog api domain parameter

### DIFF
--- a/circleci-orbs/notifier/orb.yaml
+++ b/circleci-orbs/notifier/orb.yaml
@@ -31,13 +31,18 @@ jobs:
         description: |
           Title (eg. key) of the event.
         type: string
+      dd_domain:
+        default: "api.datadoghq.com"
+        description: |
+          Domain of datadog api. (It could be api.datadoghq.eu)
+        type: string
     steps:
       - run: apk add --no-cache --no-progress curl
       - run: |
           curl -XPOST \
             -H "Content-Type: application/json" \
             -d '{"title": "'"<<parameters.title>>"'", "text": "'"<<parameters.text>>"'", "tags": ["'"<<parameters.tag>>"'"], "alert_type": "success"}' \
-            "https://api.datadoghq.com/api/v1/events?api_key=${<<parameters.api_key>>}"
+            "https://<<parameters.dd_domain>>/api/v1/events?api_key=${<<parameters.api_key>>}"
 
   sentry-deployment:
     description: |


### PR DESCRIPTION
Please consider add a parameter to use datadog api in Europe.
```yaml      dd_domain:
        default: "api.datadoghq.com"
        description: |
          Domain of datadog api. (It could be api.datadoghq.eu)
        type: string
