### PR TITLE
chore(docker-build) introdue multi-platform build for docker-gcloud-p…

### DIFF
--- a/docker-gcloud-pubsub-emulator/Dockerfile
+++ b/docker-gcloud-pubsub-emulator/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /src
 RUN go build
 
 
-FROM google/cloud-sdk:alpine
+FROM alpine:latest
+
+ARG TARGETPLATFORM
 
 COPY --from=builder /usr/bin/wait-for /usr/bin
 COPY --from=builder /src/pubsubc /usr/bin
@@ -20,8 +22,21 @@ COPY run.sh /run.sh
 
 RUN apk add --no-cache --update \
         netcat-openbsd \
-        openjdk8-jre && \
-    gcloud components install beta pubsub-emulator
+        openjdk8-jre \ 
+        curl \
+        python3=~3.9
+RUN mkdir gcloud
+WORKDIR /gcloud
+RUN case ${TARGETPLATFORM} in \
+         "linux/amd64")  gcloud_arch=x86_64  ;; \
+         "linux/arm64")  gcloud_arch=ARM  ;; \
+    esac \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-378.0.0-linux-${gcloud_arch}.tar.gz \
+    && tar -xf google-cloud-sdk-378.0.0-linux-${gcloud_arch}.tar.gz
+
+ENV PATH $PATH:/gcloud/google-cloud-sdk/bin
+WORKDIR /
+RUN gcloud components install beta pubsub-emulator --quiet
 
 EXPOSE 8681
 


### PR DESCRIPTION
…ubsub-emulator

used following command to test it locally:
```
docker buildx build --platform linux/amd64,linux/arm64 -t seb-test:latest .
```
It took `4m 56s` to build both architecture versions locally on my machine :) 

Todo:
- [ ] integration test the build image locally 