### PR TITLE
Change to debian slim to reduce image size

### DIFF
--- a/docker-gcloud-pubsub-emulator/Dockerfile
+++ b/docker-gcloud-pubsub-emulator/Dockerfile
@@ -21,10 +21,7 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 RUN /opt/poetry/bin/poetry export -f requirements.txt --output /tmp/requirements.txt
 
-
-# Switch back to Alpine once this is resolved:
-# https://github.com/firebase/firebase-tools/issues/5256#issuecomment-1383228506
-FROM google/cloud-sdk:427.0.0
+FROM google/cloud-sdk:427.0.0-slim
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache


### PR DESCRIPTION
Current image size is 1GB, using debian slim reduces that to 380mb

Seems to work ok locally and is a compromise to using Alpine