### PR TITLE
PubSub emulator: read  config from JSON environment variable

### DIFF
--- a/docker-gcloud-pubsub-emulator/README.rst
+++ b/docker-gcloud-pubsub-emulator/README.rst
@@ -19,11 +19,6 @@ Tag description:
 * ``\d+.\d+.\d+``: the latest build for a given gcloud version
 * in addition, each commit has its commit hash user as a docker tag
 
-.. warning::
-
-    I received a bunch of reports of the emulator behaving weirdly as of gcloud
-    version 407+. If :latest isn't working for you, try out the :406.0.0 tag!
-
 Usage
 -----
 
@@ -87,6 +82,27 @@ So the full command would look like:
 
 If you want to define more projects, you'd simply add a ``PUBSUB_PROJECT2``,
 ``PUBSUB_PROJECT3``, etc.
+
+Push Subscriptions
+``````````````````
+
+By default, any subscriptions specified above will be pull subscriptions. To
+declare them as push subscriptions, you can add the following extra env var:
+
+.. code-block:: console
+
+    $ PUBSUB_PUSHENDPOINT_my-push-subscription-name=http://localhost:3001/messages
+
+In this case, when we see ``my-push-subscription-name`` listed in the
+``PUBSUB_PROJECT{n}`` env vars, we'll look at this variable and create a push
+subscription instead of a pull one.
+
+To be clear, that means the above env var will have no effect unless you *also*
+have something like:
+
+.. code-block:: console
+
+    $ PUBSUB_PROJECT1=my-topic:my-pull-subscription-name:my-push-subscription-name
 
 Liveness Probes
 ~~~~~~~~~~~~~~~

--- a/docker-gcloud-pubsub-emulator/README.rst
+++ b/docker-gcloud-pubsub-emulator/README.rst
@@ -104,6 +104,42 @@ have something like:
 
     $ PUBSUB_PROJECT1=my-topic:my-pull-subscription-name:my-push-subscription-name
 
+JSON config
+``````````````````
+
+Alternatively, you can define a JSON config via ``PUBSUB_PROJECTS`` environment variable. The format of the JSON is as follows:
+
+.. code-block:: json
+
+    {
+        "projects": [
+            {
+                "name": "project",
+                "topics": [
+                    {
+                        "name": "my-topic",
+                        "subscriptions": [
+                            {
+                                "name":"my-subscription",
+                                "push_endpoint":"http://localhost:3001/subscription-endpoint"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+So following the real-life examples from above, the full command would look like this:
+
+.. code-block:: console
+
+    $ docker run --rm -it \
+         -p 8681:8681 \
+         -e PUBSUB_PROJECTS='{"projects":[{"name":"company-dev","topics":[{"name":"invoices","subscriptions":[{"name":"invoice-calculator"}]},{"name":"chats","subscriptions":[{"name":"slack-out","push_endpoint":"http://localhost:3001/slack-out-endpoint"},{"name":"irc-out","push_endpoint":"http://localhost:3001/irc-out-endpoint"}]},{"name":"notifications","subscriptions":[]}]}]}' \
+         thekevjames/gcloud-pubsub-emulator:latest
+
+
 Liveness Probes
 ~~~~~~~~~~~~~~~
 

--- a/docker-gcloud-pubsub-emulator/pubsubc.py
+++ b/docker-gcloud-pubsub-emulator/pubsubc.py
@@ -20,9 +20,9 @@ Credit:
 
     This script was originally ported from: https://github.com/prep/pubsubc
 """
-import json
 import os
 import sys
+import json
 
 from google.cloud import pubsub_v1  # type: ignore[attr-defined]
 
@@ -60,7 +60,7 @@ def create(project: str, topics: list[str]) -> None:
             )
 
 
-def config_create(config: dict) -> None:
+def config_create(config: dict[str, dict]) -> None:
     publisher = pubsub_v1.PublisherClient()
     subscriber = pubsub_v1.SubscriberClient()
     print(f'configuring projects: {config}')

--- a/docker-gcloud-pubsub-emulator/pubsubc.py
+++ b/docker-gcloud-pubsub-emulator/pubsubc.py
@@ -20,9 +20,9 @@ Credit:
 
     This script was originally ported from: https://github.com/prep/pubsubc
 """
+import json
 import os
 import sys
-import json
 
 from google.cloud import pubsub_v1  # type: ignore[attr-defined]
 

--- a/docker-gcloud-pubsub-emulator/pubsubc.py
+++ b/docker-gcloud-pubsub-emulator/pubsubc.py
@@ -79,16 +79,16 @@ def config_create(config: dict) -> None:
                     subscription['name'],
                 )
 
-                url = subscription['push_endpoint']
-                config = None
-                if url:
+                push_config = None
+                if 'push_endpoint' in subscription:
+                    url = subscription['push_endpoint']
                     print(f'    - setting push endpoint: {url}')
-                    config = pubsub_v1.types.PushConfig(push_endpoint=url)
+                    push_config = pubsub_v1.types.PushConfig(push_endpoint=url)
 
                 subscriber.create_subscription(
                     name=subscription_name,
                     topic=topic_name,
-                    push_config=config,
+                    push_config=push_config,
                 )
 
 

--- a/docker-gcloud-pubsub-emulator/pubsubc.py
+++ b/docker-gcloud-pubsub-emulator/pubsubc.py
@@ -44,9 +44,18 @@ def create(project: str, topics: list[str]) -> None:
                 project,
                 subscription,
             )
+
+            url = os.environ.get(f'PUBSUB_PUSHENDPOINT_{subscription_name}')
+            if url:
+                print(f'    setting push endpoint: {url}')
+                config = pubsub_v1.types.PushConfig(push_endpoint=url)
+            else:
+                config = None
+
             subscriber.create_subscription(
                 name=subscription_name,
                 topic=topic_name,
+                push_config=config,
             )
 
 


### PR DESCRIPTION
Since there were some talks about the push endpoints and the fast implementation was a bit clumsy, I've added the support for the pubsub emulator to be automatically configured from JSON config.

Temporary image: [ollosh/gcloud-pubsub-emulator](https://hub.docker.com/r/ollosh/gcloud-pubsub-emulator)

### Added
- Support for JSON config via environment variable