### PR TITLE
Use slim cloud sdk base image to reduce image size

### DIFF
--- a/docker-gcloud-pubsub-emulator/Dockerfile
+++ b/docker-gcloud-pubsub-emulator/Dockerfile
@@ -24,7 +24,7 @@ RUN /opt/poetry/bin/poetry export -f requirements.txt --output /tmp/requirements
 
 # Switch back to Alpine once this is resolved:
 # https://github.com/firebase/firebase-tools/issues/5256#issuecomment-1383228506
-FROM google/cloud-sdk:452.0.1
+FROM google/cloud-sdk:452.0.1-slim
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache


### PR DESCRIPTION
I've raised this to supersede https://github.com/TheKevJames/tools/pull/529 as theres been no activity on that for a while.

Adding `-slim` does not seem to change the output of `awk -F':|-' '/cloud-sdk/ {print $3}' docker-gcloud-pubsub-emulator/Dockerfile` so i think we are OK in regards to the [comment on the other PR](https://github.com/TheKevJames/tools/pull/529#pullrequestreview-1431259193).