### PR TITLE
Add optional timeout

### DIFF
--- a/docker-gcloud-pubsub-emulator/README.rst
+++ b/docker-gcloud-pubsub-emulator/README.rst
@@ -135,6 +135,27 @@ If you want to define more projects, you'd simply add a ``PUBSUB_PROJECT2``,
 As with configuring this script via config file, you must have at least one
 configured ``topic``.
 
+Timeout
+^^^^^^^
+There are times when the Google Cloud PubSub system takes more than the default 15s
+to be ready to accept requests to create the project/topic/subscription. If you
+are getting the message:
+```
+Operation timed out
+```
+you may want to increase the timeout, by setting the environment variable
+`PUBSUB_EMULATOR_WAIT_TIMEOUT` (in seconds) to some value larger than 15.
+For example, the command below will set the timeout to be 60 seconds.
+
+.. code-block:: console
+
+   $ docker run --rm -it \
+         -p 8681:8681 \
+         -e PUBSUB_EMULATOR_WAIT_TIMEOUT=60 \
+         -e PUBSUB_PROJECT1=company-dev,invoices:invoice-calculator,chats:slack-out:irc-out,notifications \
+         thekevjames/gcloud-pubsub-emulator:latest
+
+
 Liveness Probes
 ~~~~~~~~~~~~~~~
 

--- a/docker-gcloud-pubsub-emulator/run.sh
+++ b/docker-gcloud-pubsub-emulator/run.sh
@@ -5,9 +5,12 @@
 # After it's done, port 8682 will be open to facilitate the wait-for and
 # wait-for-it scripts.
 (
-    set -eu
     echo "Waiting for emulator..."
-    /usr/bin/wait-for localhost:8681 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc
+    TIMEOUT_OPTION=""
+    if [ ! -z "$PUBSUB_EMULATOR_WAIT_TIMEOUT" ]; then
+        TIMEOUT_OPTION="-t $PUBSUB_EMULATOR_WAIT_TIMEOUT"
+    fi
+    /usr/bin/wait-for localhost:8681 $TIMEOUT_OPTION -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc
     echo "[run.sh] Done building projects/topics/subscriptions! Opening readiness port..."
     nc -lkp 8682
 ) &


### PR DESCRIPTION
This PR adds the ability to specify timeout for the wait before running `pubsubc`, via an optional `PUBSUB_EMULATOR_WAIT_TIMEOUT` environment variable.

The value of this environment variable is passed on to the `/usr/bin/wait-for`

This is added to resolve the issue where Google PubSub system takes more than 15s (default timeout for `/usr/bin/wait-for`) to be ready. 