### PR TITLE
feat(docker-gcloud-pubsub-emulator): build for arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,12 @@
 version: 2.1
 
 orbs:
-  docker: talkiq/docker@3.1.0
   linter: talkiq/linter@4.0.0
 
 executors:
   docker:
     docker:
-      - image: docker:25.0.5-git
+      - image: docker:28.3.2
     resource_class: medium
   pandoc:
     docker:
@@ -26,14 +25,14 @@ commands:
     steps:
       - when:
           condition:
-            equal: [ "atc1441-exporter", <<parameters.ident>> ]
+            equal: ["atc1441-exporter", <<parameters.ident>>]
           steps:
             - run: |
                 export ATC1441_VERSION=$(awk -F'= ' '/^version =/ {print substr($2, 2, length($2)-2)}'  docker-atc1441-exporter/pyproject.toml)
                 echo "${ATC1441_VERSION}" >/tmp/custom-tag
       - when:
           condition:
-            equal: [ "caddy-security", <<parameters.ident>> ]
+            equal: ["caddy-security", <<parameters.ident>>]
           steps:
             - run: |
                 export CADDY_VERSION=$(awk -F':|-' '/builder-alpine/ {print $2}' docker-caddy-security/Dockerfile)
@@ -41,35 +40,35 @@ commands:
                 echo "${CADDY_VERSION}-${SECURITY_VERSION}" >/tmp/custom-tag
       - when:
           condition:
-            equal: [ "fava", <<parameters.ident>> ]
+            equal: ["fava", <<parameters.ident>>]
           steps:
             - run: |
                 export FAVA_VERSION=$(awk -F'=' '/ARG FAVA_VERSION=/ {print $2}' docker-fava/Dockerfile)
                 echo "${FAVA_VERSION}" >/tmp/custom-tag
       - when:
           condition:
-            equal: [ "gcloud-pubsub-emulator", <<parameters.ident>> ]
+            equal: ["gcloud-pubsub-emulator", <<parameters.ident>>]
           steps:
             - run: |
                 export GCLOUD_VERSION=$(awk -F':|-' '/cloud-sdk/ {print $3}' docker-gcloud-pubsub-emulator/Dockerfile)
                 echo "${GCLOUD_VERSION}" >/tmp/custom-tag
       - when:
           condition:
-            equal: [ "mysqltuner", <<parameters.ident>> ]
+            equal: ["mysqltuner", <<parameters.ident>>]
           steps:
             - run: |
                 export MYSQLTUNER_VERSION=$(awk -F'=' '/VERSION=/ {print $2}' docker-mysqltuner/Makefile)
                 echo "${MYSQLTUNER_VERSION}" >/tmp/custom-tag
       - when:
           condition:
-            equal: [ "nox", <<parameters.ident>> ]
+            equal: ["nox", <<parameters.ident>>]
           steps:
             - run: |
                 export NOX_VERSION=$(awk -F'=' '/nox/ {print $3}' docker-nox/requirements.txt)
                 echo "${NOX_VERSION}" >/tmp/custom-tag
       - when:
           condition:
-            equal: [ "tuning-primer", <<parameters.ident>> ]
+            equal: ["tuning-primer", <<parameters.ident>>]
           steps:
             - run: |
                 export TUNINGPRIMER_VERSION=$(awk -F' ' '/Version:/ {print $3}' docker-tuning-primer/root/tuning-primer.sh)
@@ -88,7 +87,7 @@ commands:
       - run: docker tag "<<parameters.ident>>:${CIRCLE_SHA1:0:10}" "quay.io/thekevjames/<<parameters.ident>>:${CIRCLE_SHA1:0:10}"
       - when:
           condition:
-            equal: [ "master", <<pipeline.git.branch>> ]
+            equal: ["master", <<pipeline.git.branch>>]
           steps:
             - docker-tag-as-custom:
                 ident: <<parameters.ident>>
@@ -124,9 +123,25 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - docker/build:
-          local_image_name: "<<parameters.ident>>:${CIRCLE_SHA1:0:10}"
-          path: "docker-<<parameters.ident>>"
+      - run: echo 'linux/amd64' > /tmp/buildx-platforms
+      - when:
+          condition:
+            equal: ["gcloud-pubsub-emulator", <<parameters.ident>>]
+          steps:
+            - run: echo 'linux/amd64,linux/arm64' > /tmp/buildx-platforms
+      - run: |
+          docker buildx create
+            --name mybuilder
+            --driver docker-container
+            --bootstrap
+      - run: |
+          docker buildx build
+            --builder mybuilder
+            --progress plain
+            -f docker-<<parameters.ident>>/Dockerfile
+            -t <<parameters.ident>>:${CIRCLE_SHA1:0:10}
+            --platform $(cat /tmp/buildx-platforms)
+            docker-<<parameters.ident>>
       - docker-publish-image:
           ident: <<parameters.ident>>
       - docker-publish-readme:
@@ -138,7 +153,7 @@ jobs:
       ident:
         type: string
       prefix:
-        default: 'docker-'
+        default: "docker-"
         type: string
     steps:
       - run: apk add --no-cache --no-progress ca-certificates openssl

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,27 +15,11 @@
         {
             "matchFileNames": [
                 ".circleci/config.yml",
-                "docker-gcloud-pubsub-emulator/Dockerfile",
-            ],
-            "matchDepNames": [
-                "python",
-            ],
-            "allowedVersions": "3.9.2",
-        },
-        {
-            "matchFileNames": [
+                ".pre-commit-config.yaml",
                 "docker-atc1441-exporter/Dockerfile",
             ],
             "matchDepNames": [
                 "python",
-            ],
-            "allowedVersions": "3.9",
-        },
-        {
-            "matchFileNames": [
-                ".pre-commit-config.yaml",
-            ],
-            "matchDepNames": [
                 "python/cpython",
             ],
             "allowedVersions": "3.9",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,7 @@ repos:
       - <<: *pylint
         name: pylint-docker-gcloud-pubsub-emulator
         files: docker-gcloud-pubsub-emulator/
+        language_version: python3.13
       - <<: *pylint
         name: pylint-task
         language_version: python3.11
@@ -190,6 +191,9 @@ repos:
         files: docker-atc1441-exporter/
       - <<: *refurb
         name: refurb-docker-gcloud-pubsub-emulator
+        args:
+          - --python-version
+          - '3.13'
         files: docker-gcloud-pubsub-emulator/
       - <<: *refurb
         name: refurb-task

--- a/docker-gcloud-pubsub-emulator/Dockerfile
+++ b/docker-gcloud-pubsub-emulator/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1
 
-# TODO: why is this not in repology?
 # renovate: datasource=repology depName=debian_12/netcat-openbsd versioning=loose
 ARG NETCATOPENBSD_VERSION=1.219-1
 # renovate: datasource=pypi depName=pip
@@ -9,6 +8,10 @@ ARG PIP_VERSION=25.1.1
 ARG POETRY_VERSION=2.1.3
 # renovate: datasource=pypi depName=poetry-plugin-export
 ARG POETRYPLUGINEXPORT_VERSION=1.9.0
+# renovate: datasource=repology depName=debian_12/python3-pip versioning=loose
+ARG PYTHON3PIP_VERSION=25.1.1+dfsg-1
+# renovate: datasource=repology depName=debian_12/python3-venv versioning=loose
+ARG PYTHON3VENV_VERSION=3.13.5-1
 # renovate: datasource=github-releases depName=eficode/wait-for
 ARG WAITFOR_VERSION=2.2.4
 
@@ -20,10 +23,33 @@ RUN curl -vsSLo /tmp/wait-for "https://github.com/eficode/wait-for/releases/down
     chmod +x /tmp/wait-for
 
 
-# N.B. match to the python3 version in the gcloud image
-FROM python:3.9.2 AS builder
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:529.0.0-emulators AS base
 
-RUN python3 -m venv /opt/poetry
+ARG TARGETPLATFORM
+ARG NETCATOPENBSD_VERSION
+ARG PYTHON3PIP_VERSION
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt,id=apt-cache-$TARGETPLATFORM \
+    --mount=type=cache,sharing=locked,target=/var/lib/apt,id=apt-lib-$TARGETPLATFORM \
+    apt-get update -qy && \
+    apt-get install -qy --no-install-recommends \
+        "netcat-openbsd=${NETCATOPENBSD_VERSION}" \
+        "python3-pip=${PYTHON3PIP_VERSION}" && \
+    gcloud config set disable_usage_reporting true
+
+
+FROM base AS builder
+
+ARG TARGETPLATFORM
+ARG PYTHON3VENV_VERSION
+
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt,id=apt-cache-$TARGETPLATFORM \
+    --mount=type=cache,sharing=locked,target=/var/lib/apt,id=apt-lib-$TARGETPLATFORM \
+    apt-get install -qy --no-install-recommends \
+        "python3-venv=${PYTHON3VENV_VERSION}" && \
+    python3 -m venv /opt/poetry
 
 ARG PIP_VERSION
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -42,21 +68,7 @@ COPY pyproject.toml poetry.lock ./
 RUN /opt/poetry/bin/poetry export -f requirements.txt --output /tmp/requirements.txt
 
 
-# TODO: switch back to Alpine once this is resolved:
-# https://github.com/firebase/firebase-tools/issues/5256#issuecomment-1383228506
-# Alternatively, switch back to slim once this is resolved:
-# https://github.com/TheKevJames/tools/issues/675
-FROM google/cloud-sdk:530.0.0
-
-ARG NETCATOPENBSD_VERSION
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
-    apt-get update -qy && \
-    apt-get install -qy --no-install-recommends \
-        "netcat-openbsd=${NETCATOPENBSD_VERSION}" && \
-    gcloud config set disable_usage_reporting true
+FROM base
 
 ARG PIP_VERSION
 RUN --mount=type=cache,target=/root/.cache/pip \


### PR DESCRIPTION
Hi! First of all, thanks for maintaining your PubSub emulator Docker image. It has very nice features and helped our team quite a lot 🙂

Some colleagues are running arm64 architectures, and I've looked into updating this image to account for it. I've forked your repo and made it work, so I'm opening a PR hoping it can help others!

## Issue

We use the [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk) (from the Dockerhub) as base image, which is not available on arm64.

## Solution

We can use the Artifact Registry release [`gcr.io/google.com/cloudsdktool/google-cloud-cli`](https://console.cloud.google.com/artifacts/docker/google.com:cloudsdktool/us/gcr.io/google-cloud-cli) as an alternative base image. Some tags, like the `:emulators` tag, are released for both amd64 and arm64, which is perfect for us (see [documentation for this alternative tag on their GitHub repository](https://github.com/GoogleCloudPlatform/cloud-sdk-docker?tab=readme-ov-file#docker-image-options)).

Notice that we cannot use the Dockerhub release [`google/cloud-sdk:emulators`](https://hub.docker.com/r/google/cloud-sdk/tags), as it is not published for arm64 over there. 

A nice side effect is that this base image is significantly lighter. I've published [the resulting image on my Dockerhub](https://hub.docker.com/r/aabrioux/gcloud-pubsub-emulator) to test it and confirmed with my colleagues that they could run it on their Mac M1. The result weighs ~500MB vs. ~1.3GB before.

I've also updated the CircleCI configuration, but could not test that part. I am not 100% confident that it will work first try, but that should be a good start 🙂 Let me know what you think!

## References

Fixes https://github.com/TheKevJames/tools/issues/453