### PR TITLE
ci: build all docker images as multi-arch (amd64+arm64)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,24 +226,16 @@ workflows:
             - linter/pre-commit
       - docker-workflow:
           name: docker-workflow-<<matrix.ident>>
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           matrix:
             parameters:
               ident:
                 - atc1441-exporter
                 - caddy-security
                 - fava
+                - gcloud-pubsub-emulator
                 - mysqltuner
                 - tuning-primer
-          requires:
-            - docker-build-readme-<<matrix.ident>>
-      - docker-workflow:
-          name: docker-workflow-<<matrix.ident>>
-          platforms: "linux/amd64,linux/arm64"
-          matrix:
-            parameters:
-              ident:
-                - gcloud-pubsub-emulator
           requires:
             - docker-build-readme-<<matrix.ident>>
       - deploy-autodecline-meetings:

--- a/docker-caddy-security/Dockerfile
+++ b/docker-caddy-security/Dockerfile
@@ -4,10 +4,12 @@
 ARG CADDYSECURITY_VERSION=v1.1.64
 
 
-FROM docker.io/library/caddy:2.11.4-builder-alpine AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/caddy:2.11.4-builder-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
 ARG CADDYSECURITY_VERSION
-RUN GOTOOLCHAIN=auto xcaddy build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH GOTOOLCHAIN=auto xcaddy build \
     --with "github.com/greenpau/caddy-security@${CADDYSECURITY_VERSION}"
 
 


### PR DESCRIPTION
Consolidates the amd64-only docker-workflow matrix into the multi-arch
matrix. atc1441-exporter, caddy-security, fava, mysqltuner, and
tuning-primer all build cleanly for linux/arm64, so they join
gcloud-pubsub-emulator in producing amd64+arm64 images.

docker-ubuntu32 is intentionally excluded as it is inherently i386-only.

Closes #1321
